### PR TITLE
cleanup dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM ubuntu:14.04
+FROM debian:jessie
 MAINTAINER Michal Raczka me@michaloo.net
 
 # install curl and fluentd deps
 RUN apt-get update \
-    && apt-get install -y curl libcurl4-openssl-dev ruby ruby-dev make
+    && apt-get install -y build-essential curl libcurl4-openssl-dev ruby ruby-dev
 
 # install fluentd with plugins
 RUN gem install fluentd --no-ri --no-rdoc \
     && fluent-gem install fluent-plugin-elasticsearch \
     fluent-plugin-record-modifier fluent-plugin-exclude-filter \
-    && mkdir /etc/fluentd/
+    && mkdir /etc/fluentd/ && gem list
 
 # install docker-gen
 RUN cd /usr/local/bin \

--- a/bin/start
+++ b/bin/start
@@ -14,6 +14,4 @@ trap 'kill $(jobs -p)' EXIT
 
 /usr/local/bin/fluentd -c /etc/fluentd/fluentd.conf &
 sleep 2
-/usr/local/bin/docker-gen -watch -notify "kill -s 1 $!" /root/fluentd.tmpl /etc/fluentd/fluentd.conf &
-
-wait
+/usr/local/bin/docker-gen -watch -notify "kill -s 1 $!" /root/fluentd.tmpl /etc/fluentd/fluentd.conf


### PR DESCRIPTION
In trying to track down why fluentd gets into an unhappy state sometimes and stops reloading (unable to reproduce outside production running for weeks on end), ive cleaned up the Dockerfile some. Hoping there is a fix in the latest fluentd gem that will prevent this from happening :)

```
2015/05/12 09:01:45 Received event start for container f550e1bffd67
2015/05/12 09:01:45 Generated '/etc/fluentd/fluentd.conf' from 16 containers
2015/05/12 09:01:45 Running 'kill -s 1 9'
2015-05-12 09:01:45 +0000 [info]: restarting
2015-05-12 09:01:45 +0000 [info]: reading config file path="/etc/fluentd/fluentd.conf"
2015/05/12 09:01:50 Received event die for container f550e1bffd67
2015/05/12 09:01:52 Generated '/etc/fluentd/fluentd.conf' from 15 containers
2015/05/12 09:01:52 Running 'kill -s 1 9'
2015-05-12 09:01:52 +0000 [info]: restarting
2015-05-12 09:01:52 +0000 [info]: reading config file path="/etc/fluentd/fluentd.conf"
2015/05/12 09:01:54 Received event die for container fc8472b7fe6b
2015/05/12 09:01:55 Generated '/etc/fluentd/fluentd.conf' from 14 containers
2015/05/12 09:01:55 Running 'kill -s 1 9'
2015-05-12 09:01:55 +0000 [info]: restarting
2015-05-12 09:01:55 +0000 [info]: reading config file path="/etc/fluentd/fluentd.conf"
2015/05/12 09:01:58 Received event die for container 4c09a4453d9a
2015/05/12 09:01:58 Generated '/etc/fluentd/fluentd.conf' from 13 containers
2015/05/12 09:01:58 Running 'kill -s 1 9'
2015-05-12 09:01:58 +0000 [info]: restarting
2015-05-12 09:01:58 +0000 [info]: reading config file path="/etc/fluentd/fluentd.conf"
```
